### PR TITLE
Quit gracefully if we fail to use the font

### DIFF
--- a/badger
+++ b/badger
@@ -45,7 +45,12 @@ def list_figlet_fonts(ctx, value):
 def txt2img(outfilename, filename, font, leading, tracking, bgcolor, textcolor, width, figlet, figlet_font):
     # load the font
     fontpath = os.path.join(FONT_DIR, "%s.pil" % font)
-    font = ImageFont.load(fontpath)
+    try:
+        font = ImageFont.load(fontpath)
+    except (IOError, OSError) as err:
+        print("Could not find or use the font " + font + " (after looking for it at " + fontpath + " ).")
+        print("The actual error was: " + format(err))
+        sys.exit()
 
     # is the source file an image? If so, convert to text first
     import magic


### PR DESCRIPTION
Currently, if something goes wrong with the loading of a font, badger
just gives the user a stack trace.

Unfortunately, according to the documentation[1], PIL.ImageFont.load
only raises one type of exception (IOError), and supposedly that
happens "If the file could not be read".  In truth, this exception is
also raised in many other sittuations where the usage of the font
fails, but, until we lack better information from there, we will at
least show a generic "could not find or use the font" error,
indicating the font and the path we're looking for it.

Also, it seems that, despite what the documentation states, recent
versions raise an OSError instead[2], so we are catching those two,
and dealing with them in the exact same way.

In any case, we also print the user the (less friendly, possibly more
useful) Exception error message coming from PIL.

[1] https://pillow.readthedocs.io/en/stable/reference/ImageFont.html#PIL.ImageFont.load
[2] https://github.com/python-pillow/Pillow/commit/538d9e2e5d252bea23e12da08495945d776aed78#diff-0b53b789652f38dc633674dd3671e636L82